### PR TITLE
Fix hangs on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,15 @@ jobs:
         # Since PiecewiseAffineApprox doesn't have binary dependencies, only test on a subset
         # of possible platforms.
         include:
-          - version: '1'  # The latest point-release (Linux)
+          - version: ['lts', '1']  # LTS + latest point-release (Linux)
             os: ubuntu-latest
             arch: x64
-          - version: '1'  # The latest point-release (Windows)
+          - version: ['lts', '1']  # LTS + latest point-release (Windows)
             os: windows-latest
             arch: x64
-          - version: '1.9'  # 1.9, not 1.6 LTS (64-bit Linux)
-            os: ubuntu-latest
-            arch: x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Since PiecewiseAffineApprox doesn't have binary dependencies, only test on a subset
-        # of possible platforms.
-        include:
-          - version: ['lts', '1']  # LTS + latest point-release (Linux)
-            os: ubuntu-latest
-            arch: x64
-          - version: ['lts', '1']  # LTS + latest point-release (Windows)
-            os: windows-latest
-            arch: x64
+        version: ['lts', '1']
+        os: [ubuntu-latest, windows-latest]
+        arch: [x64]
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  token: 3c305759-ecc3-419d-aee0-20ab9a53d1e9

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiecewiseAffineApprox"
 uuid = "029c5f1c-0dc4-4551-8b87-a10b73fe3713"
 authors = ["Truls Flatberg <Truls.Flatberg@sintef.no>, Lars Hellemo <Lars.Hellemo@sintef.no>, Thiago Silva <Thiago.Silva.sintef.no>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -24,7 +24,7 @@ MakieExt = "Makie"
 Combinatorics = "1"
 Distributions = "0.25"
 JuMP = "1"
-julia = "^1.9"
+julia = "1.10"
 Makie = "0.21"
 StableRNGs = "1"
 Statistics = "1"

--- a/src/kazda_li.jl
+++ b/src/kazda_li.jl
@@ -94,13 +94,13 @@ function convexify(
 
     obj_val = objective_value(m)
     if obj_val == 0
-        @info "Data points are $(curv_string)"
+        @debug "Data points are $(curv_string)"
         return f
     end
 
     pts_adj = count(v -> v > 0, value.(s⁺ + s⁻))
 
-    @info "Data are not $(curv_string), dev = $(round(obj_val; digits=3)), $(pts_adj) point(s) adjusted"
+    @debug "Data are not $(curv_string), dev = $(round(obj_val; digits=3)), $(pts_adj) point(s) adjusted"
     values = [f.values[l] + value(s⁺[l]) - value(s⁻[l]) for l ∈ 1:K]
     return FunctionEvaluations(f.points, values)
 end
@@ -280,7 +280,7 @@ function _progressive_pwa(
         p += 1
         pwa_red = _allocation_improvement(f, p, U, optimizer)
     end
-    @info "Fitting finished, error = $(round(_approx_error(f, pwa_red, metric); digits = 3)), p = $p"
+    @debug "Fitting finished, error = $(round(_approx_error(f, pwa_red, metric); digits = 3)), p = $p"
     return pwa_red
 end
 

--- a/src/kazda_li.jl
+++ b/src/kazda_li.jl
@@ -161,8 +161,8 @@ function _reduced_order_pwa(
     optimizer,
     μ = 1e-4,
 ) where {D}
+    yield()
     K = length(f)
-
     m = Model(optimizer)
     @variable(m, ared[1:p, 1:D])
     @variable(m, bred[1:p])

--- a/src/kazda_li.jl
+++ b/src/kazda_li.jl
@@ -161,7 +161,8 @@ function _reduced_order_pwa(
     optimizer,
     μ = 1e-4,
 ) where {D}
-    yield()
+    yield() # Avoid blocking of main thread causing hangs in some cases, see
+            # https://github.com/sintefore/PiecewiseAffineApprox.jl/issues/11
     K = length(f)
     m = Model(optimizer)
     @variable(m, ared[1:p, 1:D])

--- a/src/magnani_boyd.jl
+++ b/src/magnani_boyd.jl
@@ -54,7 +54,7 @@ function _convex_linearization_mb(X::Matrix, z::Vector, options::Cluster)
     strict = options.strict
     optimizer = options.optimizer
 
-    @info "Starting heuristic search "
+    @debug "Starting heuristic search "
     approxes = collect(
         fetch.(
             @spawn _convex_linearization_mb_single(
@@ -70,7 +70,7 @@ function _convex_linearization_mb(X::Matrix, z::Vector, options::Cluster)
     )
     min_error, pwa_best = argmin(first, approxes)
 
-    @info "Terminating search - best approximation error = $(min_error) ($metric)"
+    @debug "Terminating search - best approximation error = $(min_error) ($metric)"
     return pwa_best
 end
 


### PR DESCRIPTION
EDIT: Removing `@info` or using `@debug` instead was not actually a working solution. Yielding, as suggested in #11 seems to give better results. We may still want to `@debug`, or should we revert to `@info`?


The use of `@info` caused problems in some cases due to multi-threading (fixes #11).

Switching to `@debug` seems a natural first step, then one may reenable the printouts as needed when debugging?

Also updated lower bound on Julia to v1.10 (new LTS) and updated CI accordingly.