### PR TITLE
Correct printing for concave functions

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -152,8 +152,8 @@ function _write_planes(io::IO, C::Curvature, planes::Vector{Plane{D}}) where {D}
         println(io, " ", _write_plane(C, p))
     end
 end
-_write_plane(c::Convex, plane) = "z ≥ $(_xepr(plane.α)) $(plane.β)"
-_write_plane(c::Concave, plane) = "z ≤ $(_xepr(plane.α)) $(plane.β)"
+_write_plane(c::Convex, plane) = "z ≥ $(_xepr(plane.α))$(plane.β)"
+_write_plane(c::Concave, plane) = "z ≤ $(_xepr(-1 .* plane.α))$(-plane.β)"
 function _xepr(α)
     x = ["x₁", "x₂", "x₃", "x₄", "x₅"]
     expr = ""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ const qp_optimizer = optimizer_with_attributes(
 @testset "PiecewiseAffineApprox" begin
     nologger = ConsoleLogger(devnull, Logging.Debug)
     with_logger(nologger) do
+        include("test_types.jl")
         include("testquadapprox.jl")
         include("convex_interpolation.jl")
         include("testconvexapprox.jl")

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -1,0 +1,12 @@
+@testset "PWA printing" begin
+    pwa = PWAFunc{Convex,2}([Plane([1, 2], 1), Plane([-3, 1], -2)])
+
+    @test summary(pwa) == "PWAFunc{Convex, 2} with 2 planes"
+    @test repr(MIME("text/plain"), pwa) ==
+          "PWAFunc{Convex, 2} with 2 planes:\n z ≥ 1 x₁ + 2 x₂ + 1\n z ≥ -3 x₁ + 1 x₂ + -2\n"
+
+    pwa = PWAFunc{Concave,2}([Plane([1, 2], 1), Plane([-3, 1], -2)])
+    @test summary(pwa) == "PWAFunc{Concave, 2} with 2 planes"
+    @test repr(MIME("text/plain"), pwa) ==
+          "PWAFunc{Concave, 2} with 2 planes:\n z ≤ -1 x₁ + -2 x₂ + -1\n z ≤ 3 x₁ + -1 x₂ + 2\n"
+end


### PR DESCRIPTION
This PR fixes #18 . Started work on more basic testing of the types used, but so far only checked the printing.  